### PR TITLE
feat: Add warmup_ratio argument for learning rate scheduling

### DIFF
--- a/train_tiny_stories.py
+++ b/train_tiny_stories.py
@@ -288,6 +288,12 @@ parser.add_argument(
     default=None,
     help="Random seed for reproducibility (default: None, random behavior)",
 )
+parser.add_argument(
+    "--warmup_ratio",
+    type=float,
+    default=0.0,
+    help="Ratio of total training steps used for linear warmup from 0 to learning_rate (default: 0.0)",
+)
 
 args = parser.parse_args()
 
@@ -526,6 +532,7 @@ training_args = TrainingArguments(
     metric_for_best_model="eval_loss",  # Use evaluation loss to determine the best model
     greater_is_better=False,  # Lower loss is better
     lr_scheduler_type=args.lr_scheduler_type,  # How the learning rate changes over time (e.g., 'linear' decay).
+    warmup_ratio=args.warmup_ratio, # Ratio of total steps for linear warmup
 )
 
 # Step 8: Create data collator for causal language modeling
@@ -620,6 +627,7 @@ training_params = {
         "per_device_train_batch_size": args.batch_size,
         "gradient_accumulation_steps": training_args.gradient_accumulation_steps,
         "num_train_epochs": args.epochs,
+        "warmup_ratio": args.warmup_ratio, # Add warmup ratio here
     },
 }
 # Use cache_manager method
@@ -720,6 +728,7 @@ if __name__ == "__main__":
         f"Training with {len(train_subset)} examples, total requested epochs: {args.epochs}"
     )
     print(f"Model configuration: {args.dimensions} dimensions, {args.layers} layers, {args.heads} heads")
+    print(f"Learning rate: {args.learning_rate}, Warmup ratio: {args.warmup_ratio}, LR Scheduler: {args.lr_scheduler_type}") # Added warmup_ratio here
     if args.filter_word:
         print(
             f"Dataset filtered to include only examples with the word: '{args.filter_word}'"

--- a/train_tiny_stories.py
+++ b/train_tiny_stories.py
@@ -308,6 +308,16 @@ if args.dimensions % args.heads != 0:
 # --- End Validation Step ---
 
 
+# --- New Validation Step for warmup_ratio ---
+if not (0.0 <= args.warmup_ratio <= 1.0):
+    print(
+        f"\\nERROR: warmup_ratio ({args.warmup_ratio}) must be between 0.0 and 1.0 (inclusive)."
+    )
+    print("Tip: Adjust --warmup_ratio to a value in this range.")
+    sys.exit(1)
+# --- End Validation Step ---
+
+
 # Device and precision selection
 if args.device:
     device = args.device


### PR DESCRIPTION
This PR introduces a new command-line argument `--warmup_ratio` to the `train_tiny_stories.py` script. This argument allows users to specify the fraction of the total training steps that should be dedicated to a linear learning rate warmup, starting from 0 and increasing to the configured `learning_rate`.

Adding a warmup phase can help stabilize training, especially in the early stages, by preventing large gradient updates when the model weights are randomly initialized.

**Update:** Added validation to ensure `warmup_ratio` is between 0.0 and 1.0.

## Changes Made

- Added the `--warmup_ratio` argument to the `argparse` setup in `train_tiny_stories.py` with a default value of `0.0`.
- **Added validation:** Check if `args.warmup_ratio` is within the range [0.0, 1.0]. If not, print an error and exit.
- Passed the `warmup_ratio` value from the arguments to the `transformers.TrainingArguments`.
- Included `warmup_ratio` in the parameters used for generating the training cache key to ensure runs with different warmup ratios are cached separately.
- Updated the final summary print statement to include the configured `warmup_ratio`.

## How to Use

To use the warmup feature, simply add the `--warmup_ratio` flag followed by a float value between 0.0 and 1.0 when running the script. For example:

```bash
python train_tiny_stories.py --warmup_ratio 0.1 # Use 10% of steps for warmup